### PR TITLE
Add cypress tests for main page

### DIFF
--- a/ffxiv-mount-companion/cypress/e2e/logo_page.cy.js
+++ b/ffxiv-mount-companion/cypress/e2e/logo_page.cy.js
@@ -9,7 +9,8 @@ describe('should visit the logo page', () => {
       }
     )
   })
-  it('should display the logo page', () => {
+
+  it('should display the logo page and navigate to the main page', () => {
     cy.visit("http://localhost:3000/");
     cy.get(".ffxiv-logo").should('exist')
     .get(".black-chocobo").should('exist')

--- a/ffxiv-mount-companion/cypress/e2e/main-page.cy.js
+++ b/ffxiv-mount-companion/cypress/e2e/main-page.cy.js
@@ -1,0 +1,86 @@
+describe('Should visit the main page', () => {
+  beforeEach(() => {
+    cy.intercept('GET', 'https://ffxivcollect.com/api/mounts/', {
+      statusCode: 200,
+      fixture: 'mountsData',
+    });
+  });
+
+  it('should show mount cards on the main page', () => {
+    cy.visit('http://localhost:3000/main');
+    cy.get('.header')
+      .should('exist')
+      .get('h1')
+      .should('contain', 'FFXIV Mount Companion')
+      .get('.chocobo-icon')
+      .should('exist')
+      .get('.ffxiv-logo')
+      .should('exist')
+      .get('button')
+      .should('contain', 'My Mounts')
+      .get('#search')
+      .should('exist')
+      .get('.mounts-container')
+      .children()
+      .first()
+      .within(() => {
+        cy.contains('h3', 'Quaqua');
+        cy.contains(
+          'p',
+          "Summon forth your quaqua, a familiar hailing from the south sea isles that has either a permanent snarl or grin, depending on one's outlook on life.",
+        )
+          .get('svg')
+          .should('exist');
+      });
+    cy.get('.mounts-container')
+      .children()
+      .last()
+      .within(() => {
+        cy.contains('h3', 'Island Peerifool');
+        cy.contains(
+          'p',
+          'Summon forth your island Peerifool. If anyone asks, it bears no relation whatsoever to a certain malicious rotting vegetable.',
+        )
+          .get('svg')
+          .should('exist');
+      });
+    cy.get('.mounts-container').children().should('have.length', 5);
+  });
+  it('should click to collect a mount and navigate to the my collected mounts page and be able to remove a collected mount', () => {
+    cy.visit('http://localhost:3000/main')
+      .get('.mounts-container')
+      .children()
+      .first()
+      .within(() => {
+        cy.contains('h3', 'Quaqua');
+        cy.contains(
+          'p',
+          "Summon forth your quaqua, a familiar hailing from the south sea isles that has either a permanent snarl or grin, depending on one's outlook on life.",
+        )
+          .get('svg')
+          .should('exist')
+          .click();
+      });
+    cy.get('button').click().url().should('contain', '/collectedmounts');
+    cy.get('.collected-mounts-container').children().should('have.length', 1);
+    cy.get('.collected-mounts-container')
+      .children()
+      .first()
+      .within(() => {
+        cy.contains('h3', 'Quaqua');
+        cy.contains(
+          'p',
+          "Summon forth your quaqua, a familiar hailing from the south sea isles that has either a permanent snarl or grin, depending on one's outlook on life.",
+        )
+          .get('svg')
+          .should('exist')
+          .click();
+      });
+    cy.get('div.firebird')
+      .should('exist')
+      .get('.no-favorites')
+      .should('contain', "You don't have any mounts yet, add some!");
+    cy.get('.collected-mounts-container').children().should('have.length', 0);
+    cy.get('.back-to-all-btn').click().url().should('contain', '/main');
+  });
+});

--- a/ffxiv-mount-companion/cypress/fixtures/singleMountData.json
+++ b/ffxiv-mount-companion/cypress/fixtures/singleMountData.json
@@ -1,0 +1,26 @@
+{
+  "id": 334,
+  "name": "Spectral Statice",
+  "description": "Summon forth your spectral Statice, an avatar of the mischief-loving faerie from Aloalo Island.",
+  "enhanced_description": "This mischief-loving faerie was originally companion to a scholar, but her aether refused to disperse in the wake of her master's death. After enduring a dull existence for long years, she found in you someone who could provide her with excitement, and thus did she weave an avatar of herself to join you on adventures.",
+  "tooltip": "Most serious scholars consider it little more than a faerie tale. - Phillice",
+  "movement": "Airborne",
+  "seats": 1,
+  "order": 272,
+  "order_group": 107,
+  "patch": "6.51",
+  "item_id": null,
+  "tradeable": false,
+  "owned": "8.6%",
+  "image": "https://ffxivcollect.com/images/mounts/large/334.png",
+  "icon": "https://ffxivcollect.com/images/mounts/small/334.png",
+  "bgm": "https://ffxivcollect.com/music/BGM_Ride_VVD05.ogg",
+  "sources": [
+    {
+      "type": "Achievement",
+      "text": "Good-willed Hunting",
+      "related_type": "Achievement",
+      "related_id": 3347
+    }
+  ]
+}

--- a/ffxiv-mount-companion/pull_request_template.md
+++ b/ffxiv-mount-companion/pull_request_template.md
@@ -13,6 +13,7 @@ Type of change
 - [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
 - [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
 - [ ]  Skip all the other stuff and briefly explain the fix.
+- [ ]  Testing
 
 Checklist:
 


### PR DESCRIPTION
What I did: Added cypress testing for main page, this test goes from the main page and also to the favorites page to test when a user favorites a mount from the main page. 

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.
- [x]  Testing

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next?
Cypress testing for invidualMountCardPage 
