### PR TITLE
Add local storage to get the collected mounts to persist on page refresh

### DIFF
--- a/ffxiv-mount-companion/src/components/App/App.css
+++ b/ffxiv-mount-companion/src/components/App/App.css
@@ -1,0 +1,3 @@
+* {
+  font-family: 'Righteous', 'sans-serif'
+}

--- a/ffxiv-mount-companion/src/components/App/App.js
+++ b/ffxiv-mount-companion/src/components/App/App.js
@@ -26,38 +26,31 @@ function App() {
   }, []);
 
   useEffect(() => {
-    localStorage.setItem('collectedMounts', JSON.stringify(collectedMounts))
-    
-  }, [collectedMounts]);
-  
-  useEffect(() => {
     const storedCollectedMounts = localStorage.getItem('collectedMounts');
     if (storedCollectedMounts) {
       setCollectedMounts(JSON.parse(storedCollectedMounts));
     }
   }, []);
-
-
+  
   const openIndividualMountPage = mountId => {
     setSelectedMountId(mountId);
     navigate(`/mount/${mountId}`);
   };
-
-  const toggleCollectedMounts = mount => {
-    const isNowCollected = collectedMounts.some(
-      favMount => favMount.id === mount.id,
-    );
-
+  
+  const toggleCollectedMounts = (mount) => {
+    const isNowCollected = collectedMounts.some((favMount) => favMount.id === mount.id);
+  
     if (isNowCollected) {
-      const updatedCollected = collectedMounts.filter(
-        favMount => favMount.id !== mount.id,
-      );
+      const updatedCollected = collectedMounts.filter((favMount) => favMount.id !== mount.id);
       setCollectedMounts(updatedCollected);
+      localStorage.setItem('collectedMounts', JSON.stringify(updatedCollected));
     } else {
-      setCollectedMounts(prevCollected => [...prevCollected, mount]);
+      setCollectedMounts((prevCollected) => [...prevCollected, mount]);
+      localStorage.setItem('collectedMounts', JSON.stringify([...collectedMounts, mount]));
     }
   };
-
+      
+   
   return (
     <main className="app">
       <Routes>

--- a/ffxiv-mount-companion/src/components/CollectedMountsDisplay/CollectedMountsDisplay.js
+++ b/ffxiv-mount-companion/src/components/CollectedMountsDisplay/CollectedMountsDisplay.js
@@ -14,17 +14,6 @@ const CollectedMountsDisplay = ({
   toggleCollectedMounts,
   openIndividualMountPage,
 }) => {
-  const { id } = useParams();
-  const selectedMountId = parseInt(id);
-
-  const selectedMount = collectedMounts.find(
-    mount => mount.id === selectedMountId,
-  );
-
-  // useEffect(() => {
-  //   localStorage.setItem('collectedMounts', JSON.stringify(collectedMounts))
-    
-  // }, [collectedMounts]);
 
   const displayCollectedMounts = collectedMounts.map(mount => (
     <MountCard

--- a/ffxiv-mount-companion/src/components/LogoPage/LogoPage.scss
+++ b/ffxiv-mount-companion/src/components/LogoPage/LogoPage.scss
@@ -15,6 +15,6 @@
 }
 
 .black-chocobo {
-  margin-top: 10%;
+  margin-top: 3%;
   height: 25em;
 }

--- a/ffxiv-mount-companion/src/components/Search/Search.js
+++ b/ffxiv-mount-companion/src/components/Search/Search.js
@@ -12,14 +12,12 @@ const Search = ({ mounts, setFilteredMounts, onSearch }) => {
   };
 
   useEffect(() => {
-    console.log('Search Term:', searchTerm);
     const lowerCaseTerm = searchTerm.toLowerCase();
   
     const filteredMounts = searchTerm
       ? mounts.filter(mount => mount.name.toLowerCase().includes(lowerCaseTerm))
       : mounts;
   
-    console.log('Filtered Mounts:', filteredMounts);
     setFilteredMounts(filteredMounts);
   }, [searchTerm, setFilteredMounts]);
   


### PR DESCRIPTION
What I did: implemented local storage to keep the collectedMounts from refreshing on page refresh. They now stay until they are removed by the user

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Styling 
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.
- [ ]  Testing

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

What's next?
Fixing the search bug
